### PR TITLE
[README] CocoaPods 0.36 has been released

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ cake watch
 
 #### Podfile
 
-Version >= **0.36.0.beta.2** required
+Version >= **0.36.0** required
 
 ```shell
-gem install cocoapods --pre
+gem install cocoapods
 ```
 
 An Xcode Project is present in the `/test` folder.


### PR DESCRIPTION
We shipped CocoaPods 0.36 a while back, this PR updates references to CocoaPods to use _stable_ version instead of pre-releases.